### PR TITLE
Update sampler.jl

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -145,7 +145,7 @@ function initialize_parameters!!(
     end
     theta = vi[spl]
     length(theta) == length(init_theta) ||
-        error("Provided initial value doesn't match the dimension of the model")
+        error("Provided initial value doesn't match the dimension of the model, if using MCMCDistributed(), pass init_params as a list of length n_chains"")
 
     # Update values that are provided.
     for i in 1:length(init_theta)


### PR DESCRIPTION
When using MCMCdistributed the error occurs "dimension don't match", but the user would not have a clue why. Here I included the sentence which would advise them to use a list of init_params equal to length of the number of chains